### PR TITLE
Ampersand support for W3C, alternate directory support, image 404 fix, markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #Modern theme for Zoneminder 1.24+
-This is a fork of the work-in-progress skin for ZoneMinder version >= 1.24 by [https://github.com/kylejohnson/modern](Kyle Johnson). 
+This is a fork of the work-in-progress skin for ZoneMinder version >= 1.24 by [Kyle Johnson](https://github.com/kylejohnson/modern). 
 
 This skin is currently being developed by Emergent Ltd. Any suggestions of features, comments and code are welcome =)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-This is a fork of the work-in-progress skin for ZoneMinder version >= 1.24 by Kyle Johnson. This skin is currently being developed by Emergent Ltd. Any suggestions of features, comments and code are welcome =)
+#Modern theme for Zoneminder 1.24+
+This is a fork of the work-in-progress skin for ZoneMinder version >= 1.24 by [https://github.com/kylejohnson/modern](Kyle Johnson). 
 
-FEATURES
+This skin is currently being developed by Emergent Ltd. Any suggestions of features, comments and code are welcome =)
+
+##FEATURES
 
 * Single page for live view and playback
 * Timeline of events
@@ -9,7 +12,7 @@ FEATURES
 * Valid HTML5
 * No need for Java, Flash, etc - just a decent browser
 
-FUTURE
+##FUTURE
 
 * Exporting of multiple events
 * Improved backend (No dropping back to classic)

--- a/views/changepassword.php
+++ b/views/changepassword.php
@@ -52,7 +52,7 @@
         <h3 class="panel-title">Change Password</h3>
       </div>
       <div class="panel-body">
-        <form action="?skin=modern&view=changepassword" method="post" class="form-horizontal">
+        <form action="?skin=modern&amp;view=changepassword" method="post" class="form-horizontal">
           <fieldset>
             <div class="form-group required-control">
               <label class="col-md-3 control-label" for="currentpassword">Current Password</label>

--- a/views/events.php
+++ b/views/events.php
@@ -152,10 +152,10 @@
 
           <div id="custom-range-filters" style="display: none;" class="col-md-3">
             <div class="well well-sm">
-              <label for="startdatetime">Start Date & Time</label>
+              <label for="startdatetime">Start Date &amp; Time</label>
               <input id="startdatetime" name="startdatetime" type="text" class="form-control hasDatePicker">
 
-              <label for="enddatetime">End Date & Time</label>
+              <label for="enddatetime">End Date &amp; Time</label>
               <input id="enddatetime" name="enddatetime" type="text" class="form-control hasDatePicker">
 
             </div>

--- a/views/playback.php
+++ b/views/playback.php
@@ -82,7 +82,7 @@
                 <a href="?view=logout" class="btn btn-default playback-button" data-rel="tooltip" title="Logout"><span class="fa fa-sign-out"></span></a>
               </li>
               <li>
-                <p style="visibility: hidden;" class="currently-playing">playback date & time</p>
+                <p style="visibility: hidden;" class="currently-playing">playback date &amp; time</p>
                 <p style="visibility: hidden;" class="playback-date" data-rel="tooltip" title="The exact date and time being monitored">0000-00-00</p>
                 <p style="visibility: hidden;" class="playback-time">00:00:00</p>
               </li>

--- a/views/playevent.php
+++ b/views/playevent.php
@@ -5,7 +5,7 @@
   </head>
   <body>
     <main class="playback">
-      <img src="/zm/skins/modern/views/images/onerror.png">
+      <img src="skins/modern/views/images/onerror.png">
     </main>
     <script src="skins/<?=$skin?>/views/assets/vendor/js/jquery.min.js"></script>
     <script>
@@ -27,7 +27,7 @@
                 $eventPath = $imageData['eventPath'];
                 $dImagePath = sprintf("%s/%0".ZM_EVENT_IMAGE_DIGITS."d-diag-d.jpg", $eventPath, $counter);
                 $rImagePath = sprintf("%s/%0".ZM_EVENT_IMAGE_DIGITS."d-diag-r.jpg", $eventPath, $counter);
-                $frames[] = "/zm/" . viewImagePath($imagePath);
+                $frames[] = viewImagePath($imagePath);
           }
         }
         echo "var unprocessed = '" . implode(',', $frames) . "';";
@@ -45,7 +45,7 @@
             displayFrame(imgarray[x]);
           }
           else {
-            displayFrame('/zm/skins/modern/views/images/onerror.png');
+            displayFrame('skins/modern/views/images/onerror.png');
           }
           x++;
         }, 200);

--- a/views/playevent.php
+++ b/views/playevent.php
@@ -5,9 +5,9 @@
   </head>
   <body>
     <main class="playback">
-      <img src="skins/modern/views/images/onerror.png">
+      <img src="skins/<?php echo $skin; ?>/views/assets/images/onerror.png">
     </main>
-    <script src="skins/<?=$skin?>/views/assets/vendor/js/jquery.min.js"></script>
+    <script src="skins/<?php echo $skin; ?>/views/assets/vendor/js/jquery.min.js"></script>
     <script>
       var eid = <?=$_REQUEST['eid']?>;
 
@@ -45,7 +45,7 @@
             displayFrame(imgarray[x]);
           }
           else {
-            displayFrame('skins/modern/views/images/onerror.png');
+            displayFrame('skins/<?php echo $skin; ?>/views/assets/images/onerror.png');
           }
           x++;
         }, 200);


### PR DESCRIPTION
Pull request after trying this theme for a few minutes:
- Updated so that `&` is now `&amp;` where required.
- Updated so that `/zm/` is not hard coded into the play event code, this therefore means you can run ZoneMinder (and this theme) under any subfolder (or in the top level folder).
- Fixes a incorrect source for the error image on playback of an event.
- Converted readme to proper [markdown](https://guides.github.com/features/mastering-markdown) file.

This is my first ever 'pull request', if I've done this wrong, please do let me know!

Dan.
